### PR TITLE
Follow redirects when making request for code

### DIFF
--- a/lib/wegift/models/remote_code.rb
+++ b/lib/wegift/models/remote_code.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'faraday'
+require 'faraday_middleware'
 require 'uri'
 
 module Wegift
@@ -13,7 +14,9 @@ module Wegift
 
     def self.get(url)
       uri = URI(url)
-      conn = Faraday.new(url: "#{uri.scheme}://#{uri.host}")
+      conn = Faraday.new(url: "#{uri.scheme}://#{uri.host}") do |con|
+        con.use FaradayMiddleware::FollowRedirects, limit: 5
+      end
 
       response =  conn.get("#{uri.path}?format=json") do |req|
         req.headers['Content-Type'] = 'application/json'


### PR DESCRIPTION
Some requests for voucher codes in the wild return 302 (redirect), which are by default not followed by the requests library used (Faraday). This change specifies to follow redirects up to 5 hops.