### PR TITLE
Follow redirects for remote codes

### DIFF
--- a/lib/wegift/models/remote_code.rb
+++ b/lib/wegift/models/remote_code.rb
@@ -13,7 +13,11 @@ module Wegift
       :pin, :type
 
     def get(ctx)
-      parse(Faraday.get("#{url}?format=json") { |r| r.headers['Accept'] = 'application/json' })
+      conn = Faraday.new(url: url) do |c|
+        c.adapter :net_http
+        c.use FaradayMiddleware::FollowRedirects, limit: 5
+      end
+      parse(conn.get("#{url}?format=json") { |r| r.headers['Accept'] = 'application/json' })
     end
 
     def parse(response)

--- a/spec/wegift/models/remote_code_spec.rb
+++ b/spec/wegift/models/remote_code_spec.rb
@@ -10,17 +10,17 @@ RSpec.describe Wegift::RemoteCode do
 
     context 'when URL is invalid' do
       let(:url) { 'https://thisnotworking.yo' }
-      
+
       it 'raises error' do
         VCR.use_cassette('get_remote_code_invalid_url_does_not_exist') do
-          expect { remote_code }.to raise_error(Faraday::ClientError)
+          expect { remote_code }.to raise_error(Faraday::ConnectionFailed)
         end
       end
     end
 
     context 'when URL is valid but not known' do
       let(:url) { 'https://example.com' }
-      
+
       it 'is not successful' do
         VCR.use_cassette('get_remote_code_invalid_wrong_url_exists') do
           expect(remote_code.is_successful?).to be false
@@ -35,7 +35,7 @@ RSpec.describe Wegift::RemoteCode do
 
     context 'when URL is valid but not known to wegift' do
       let(:url) { 'https://playground.wegift.io/public/gifts/instant/c02bd09f-0000-0000-0000-38f4143a01d1' }
-      
+
       it 'is not successful' do
         VCR.use_cassette('get_remote_code_invalid_unknown_wegift_url') do
           expect(remote_code.is_successful?).to be false

--- a/wegift-ruby-client.gemspec
+++ b/wegift-ruby-client.gemspec
@@ -20,7 +20,8 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.4.0'
 
-  spec.add_dependency 'faraday', '~> 0.9', '>= 0.9.2'
+  spec.add_dependency 'faraday', '~> 1.0', '>= 1.0.0'
+  spec.add_dependency 'faraday_middleware', '~> 1.2'
   spec.add_dependency 'json', '~> 2.3', '>= 2.3.0'
 
   spec.add_development_dependency 'bundler', '~> 2.3.12'


### PR DESCRIPTION

Follow redirects when fetching remote codes because these can and do occur.
